### PR TITLE
Fix button color in dark mode

### DIFF
--- a/themes/google_theme.yaml
+++ b/themes/google_theme.yaml
@@ -107,7 +107,7 @@ Google Theme:
       # Text
       primary-text-color: rgb(242, 242, 242)
       secondary-text-color: rgb(166, 166, 166)
-      text-primary-color: var(--primary-text-color)
+      text-primary-color: rgb(33, 33, 33)
       disabled-text-color: rgba(184, 190, 199, 0.4)
       # Sidebar Menu
       sidebar-icon-color: rgb(169, 177, 188)


### PR DESCRIPTION
In dark mode, the button of the google theme has a rather bright blue color.
By the material guidelines, a button with a bright background should have a dark font color, so that it is easy to read. :)

## Before
![image](https://user-images.githubusercontent.com/10547444/154780618-f2e8fe76-01d6-4c71-9b22-42d761de6d54.png)

## After
![image](https://user-images.githubusercontent.com/10547444/154780627-ed57863e-318f-4cbe-9a34-4d324f32ef31.png)
